### PR TITLE
Refactor Trace Class

### DIFF
--- a/prorunvis/src/main/java/prorunvis/instrument/Instrumenter.java
+++ b/prorunvis/src/main/java/prorunvis/instrument/Instrumenter.java
@@ -55,7 +55,7 @@ public final class Instrumenter {
         instrumented.mkdir();
         pr.getSourceRoots().forEach(sr -> sr.saveAll(Paths.get(instrumentedOutPath)));
 
-        File proRunVisClass = new File(instrumentedOutPath + "/prorunvis/ProRunVis.java");
+        File proRunVisClass = new File(instrumentedOutPath + "/prorunvis/Trace.java");
         proRunVisClass.mkdirs();
         if (proRunVisClass.exists()) {
             proRunVisClass.delete();
@@ -84,15 +84,15 @@ public final class Instrumenter {
                 import java.io.BufferedWriter;
                 import java.io.FileWriter;
                 import java.io.IOException;
-                public final class ProRunVis {
-                    public static void proRunVisTrace(String trace) {
+                public final class Trace {
+                    public static void next_elem(int num) {
                         try {
                             BufferedWriter writer = new BufferedWriter(new FileWriter(
                             """
                             + "\"" + path + "\"" + "\n"
                             + """
                             , true));
-                            writer.write(trace + System.lineSeparator());
+                            writer.write("" + num + System.lineSeparator());
                             writer.close();
                         } catch (IOException e) {
                             throw new RuntimeException(e.getMessage());

--- a/prorunvis/src/main/java/prorunvis/trace/TraceVisitor.java
+++ b/prorunvis/src/main/java/prorunvis/trace/TraceVisitor.java
@@ -178,7 +178,7 @@ public class TraceVisitor extends ModifierVisitor<Map<Integer, Node>> {
      * @return a statement containing the call to the trace methode with the characteristics of the given statement
      */
     private Statement traceEntryCreator(final int id) {
-        return StaticJavaParser.parseStatement("prorunvis.ProRunVis.proRunVisTrace(\"" + id + "\");");
+        return StaticJavaParser.parseStatement("prorunvis.Trace.next_elem(" + id + ");");
     }
 
     /**

--- a/prorunvis/src/test/testfiles/instrument/test1solution/Test1.java
+++ b/prorunvis/src/test/testfiles/instrument/test1solution/Test1.java
@@ -1,14 +1,14 @@
 class Test1 {
 
     public static void main(String[] args) {
-        prorunvis.ProRunVis.proRunVisTrace("0");
+        prorunvis.Trace.next_elem(0);
         int x = 0;
         for (int i = 0; i < 7; i++) {
-            prorunvis.ProRunVis.proRunVisTrace("1");
+            prorunvis.Trace.next_elem(1);
             x--;
         }
         for (int i = 0; i < 7; i++) {
-            prorunvis.ProRunVis.proRunVisTrace("2");
+            prorunvis.Trace.next_elem(2);
             x--;
         }
     }

--- a/prorunvis/src/test/testfiles/instrument/test2solution/Test2.java
+++ b/prorunvis/src/test/testfiles/instrument/test2solution/Test2.java
@@ -1,20 +1,20 @@
 class Test2 {
 
     public static void main(String[] args) {
-        prorunvis.ProRunVis.proRunVisTrace("0");
+        prorunvis.Trace.next_elem(0);
         int x = 1;
         int i = 0;
         switch(x) {
             case 2:
-                prorunvis.ProRunVis.proRunVisTrace("1");
+                prorunvis.Trace.next_elem(1);
                 i++;
                 break;
             case 1:
-                prorunvis.ProRunVis.proRunVisTrace("2");
+                prorunvis.Trace.next_elem(2);
                 i--;
                 break;
             default:
-                prorunvis.ProRunVis.proRunVisTrace("3");
+                prorunvis.Trace.next_elem(3);
                 i = 0;
                 break;
         }


### PR DESCRIPTION
* Rename the class for trace-writing from `prorunvis.ProRunVis` to `prorunvis.Trace`
* Use `next_elem(int num)` instead of `proRunVisTrace(String trace)`

The first part is necessary since this project contains another class also named `prorunvis.ProRunVis` (the one with the `main()` method). The second part has a practical reason: For some experiments with KeY and jbmc, I already used custom-made `prorunvis.Trace` classes with the new method `next_elem(int num)` to avoid conversion from `String` to `int`.